### PR TITLE
Fix slow dashboard actions

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -4761,81 +4761,32 @@ class DashboardWindow(QtWidgets.QMainWindow):
         subprocess.Popen([sys.executable, script, "--crear-usuario"])
 
     def on_iniciar_digitacion(self):
-        import subprocess, os, sys
-        script = os.path.abspath(sys.argv[0])
-        subprocess.Popen([
-            sys.executable,
-            script,
-            "--iniciar-tipificacion",
-            str(self.user_id)          # <–– Aquí debe ir el user_id
-        ])
-        pass
+        """Lanza la ventana de digitación dentro del mismo proceso"""
+        iniciar_tipificacion(self._tk_root, self.conn, self.user_id)
 
     def on_iniciar_calidad(self):
-        import subprocess, os, sys
-        script = os.path.abspath(sys.argv[0])
-        subprocess.Popen([
-            sys.executable,
-            script,
-            "--iniciar-calidad",
-            str(self.user_id)          # <–– Aquí debe ir el user_id
-        ])
-        pass
+        """Lanza la ventana de control de calidad directamente"""
+        iniciar_calidad(self._tk_root, self.conn, self.user_id)
 
     def on_ver_progreso(self):
-        import subprocess, os, sys
-        script = os.path.abspath(sys.argv[0])
-        subprocess.Popen([
-            sys.executable,
-            script,
-            "--ver-progreso",
-            str(self)          # <–– Aquí debe ir el user_id
-        ])
-        pass
+        """Abre la ventana para ver el progreso acumulado"""
+        ver_progreso(self._tk_root, self.conn)
 
     def on_exportar_paquete(self):
-        import subprocess, os, sys
-        script = os.path.abspath(sys.argv[0])
-        subprocess.Popen([
-            sys.executable,
-            script,
-            "--exportar-paquete",
-            str(self.user_id)          # <–– Aquí debe ir el user_id
-        ])
-        pass
+        """Abre el diálogo para exportar paquetes"""
+        exportar_paquete(self._tk_root, self.conn)
 
     def on_actualizar_datos(self):
-        import subprocess, os, sys
-        script = os.path.abspath(sys.argv[0])
-        subprocess.Popen([
-            sys.executable,
-            script,
-            "--actualizar-datos",
-            str(self.user_id)          # <–– Aquí debe ir el user_id
-        ])
-        pass
+        """Abre la ventana para actualizar datos del usuario"""
+        actualizar_usuario(self._tk_root, self.conn, self.user_id)
 
     def on_modificar_estado_usuario(self):
-        import subprocess, os, sys
-        script = os.path.abspath(sys.argv[0])
-        subprocess.Popen([
-            sys.executable,
-            script,
-            "--desactivar-usuario",
-            str(self.user_id)          # <–– Aquí debe ir el user_id
-        ])
-        pass
-    
+        """Permite modificar el estado de usuarios"""
+        modificar_estado_usuario(self._tk_root, self.conn)
+
     def on_modificar_radicado(self):
-        import subprocess, os, sys
-        script = os.path.abspath(sys.argv[0])
-        subprocess.Popen([
-            sys.executable,
-            script,
-            "--modificar-radicado",
-            str(self.user_id)          # <–– Aquí debe ir el user_id
-        ])
-        pass
+        """Muestra la interfaz para modificar radicados"""
+        modificar_radicado(self._tk_root, self.conn, self.user_id)
 
 
 if __name__ == "__main__":

--- a/login_app.py
+++ b/login_app.py
@@ -123,39 +123,28 @@ def check_for_update_and_exit_if_needed():
         os._exit(0)
 
 def run_dashboard_from_args():
-    # Si estamos en el exe congelado y el primer arg es dashboard.py
-    if getattr(sys, 'frozen', False) \
+    """Si la aplicación se ejecuta con los argumentos de Dashboard,
+    inicia la ventana principal directamente y finaliza el proceso
+    de login."""
+
+    if getattr(sys, "frozen", False) \
        and len(sys.argv) >= 2 \
        and os.path.basename(sys.argv[1]).lower() == "dashboard.py":
-        # argv[2], [3], [4] son user_id, first_name, last_name
+        # argv[2], [3] y [4] son user_id, first_name y last_name
         try:
-            uid   = int(sys.argv[2])
-            fn    = sys.argv[3]
-            ln    = sys.argv[4]
+            uid = int(sys.argv[2])
+            fn  = sys.argv[3]
+            ln  = sys.argv[4]
         except Exception:
-            print("Uso incorrecto: login_app.exe dashboard.py <id> <nombre> <apellido>")
+            print(
+                "Uso incorrecto: login_app.exe dashboard.py <id> <nombre> <apellido>"
+            )
             sys.exit(1)
-        # Conectamos
-        conn = conectar_sql_server('DB_DATABASE')
-        if conn is None:
-            raise RuntimeError("No se pudo conectar a la BD.")
-        # Creamos root y abrimos el dashboard
-        def run_dashboard_from_args():
-            if getattr(sys, 'frozen', False) \
-            and len(sys.argv) >= 2 and os.path.basename(sys.argv[1]).lower() == "dashboard.py":
-                try:
-                    uid = int(sys.argv[2])
-                    fn  = sys.argv[3]
-                    ln  = sys.argv[4]
-                except Exception:
-                    print("Uso incorrecto: login_app.exe dashboard.py <id> <nombre> <apellido>")
-                    sys.exit(1)
 
-                # Arrancamos Qt en vez de CTk
-                app = QtWidgets.QApplication(sys.argv)
-                window = DashboardWindow(uid, fn, ln)   # sin parent=…
-                window.show()
-                sys.exit(app.exec_())
+        app = QtWidgets.QApplication(sys.argv)
+        window = DashboardWindow(uid, fn, ln)
+        window.show()
+        sys.exit(app.exec_())
 
 
 # Ejecutamos la detección *antes* de definir nada más


### PR DESCRIPTION
## Summary
- call dashboard actions directly instead of spawning new Python processes

## Testing
- `python -m py_compile login_app.py`
- `python -m py_compile dashboard.py db_connection.py version.py`


------
https://chatgpt.com/codex/tasks/task_b_683bceedffac8331a98e78a2af2a037d