### PR TITLE
Fix theme persistence on login toggle

### DIFF
--- a/login_app.py
+++ b/login_app.py
@@ -630,7 +630,6 @@ class LoginWindow(QtWidgets.QWidget):
     def toggle_theme(self):
         app = QtWidgets.QApplication.instance()
         settings = QtCore.QSettings("Procesos Y Servicios", "CapturadorDeDatos")
-        settings.setValue("theme", "dark" if self.is_dark else "light")
 
         if self.is_dark:
             # → PASAR A CLARO
@@ -730,7 +729,10 @@ class LoginWindow(QtWidgets.QWidget):
 
         # Aplica TODO el CSS de una sola vez:
         app.setStyleSheet(light_ss if self.is_dark else dark_ss)
+        # Invertimos el estado actual
         self.is_dark = not self.is_dark
+        # Guardamos el tema resultante para próximas ejecuciones
+        settings.setValue("theme", "dark" if self.is_dark else "light")
 
 # Función para enviar código por correo
 def enviar_codigo_por_email(email_destino):


### PR DESCRIPTION
## Summary
- save the new theme preference after toggling in the login window

## Testing
- `python3 -m py_compile login_app.py`

------
https://chatgpt.com/codex/tasks/task_b_683bdb2ebf8883318fd1acc206682172