### PR TITLE
Update role combo styling and status reset

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -524,14 +524,18 @@ def iniciar_tipificacion(parent_root, conn, current_user_id):
 
     def on_close():
         # Si la ventana se cierra sin guardar, cambiamos el estado de la asignación a 1
-        cur = conn.cursor()
-        cur.execute("""
-            UPDATE ASIGNACION_TIPIFICACION 
-            SET STATUS_ID = 1 
-            WHERE RADICADO = %s
-        """, (radicado,))
-        conn.commit()
-        cur.close()
+        if radicado is not None:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                UPDATE ASIGNACION_TIPIFICACION
+                SET STATUS_ID = 1
+                WHERE RADICADO = %s
+                """,
+                (radicado,),
+            )
+            conn.commit()
+            cur.close()
         win.destroy()  # Cierra la ventana después de actualizar el estado
 
     # Configurar el evento de cierre de la ventana
@@ -1721,6 +1725,8 @@ def iniciar_calidad(parent_root, conn, current_user_id):
         win.clipboard_append(entry_radicado_var.get())
         
     def load_assignment():
+        nonlocal radicado, nit, factura
+
         cur = conn.cursor()
         cur.execute("""
             SELECT TOP 1 RADICADO, NIT, FACTURA
@@ -1864,14 +1870,18 @@ def iniciar_calidad(parent_root, conn, current_user_id):
 
     def on_close():
         # Si la ventana se cierra sin guardar, cambiamos el estado de la asignación a 1
-        cur = conn.cursor()
-        cur.execute("""
-            UPDATE ASIGNACION_TIPIFICACION 
-            SET STATUS_ID = 1 
-            WHERE RADICADO = %s
-        """, (radicado,))
-        conn.commit()
-        cur.close()
+        if radicado is not None:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                UPDATE ASIGNACION_TIPIFICACION
+                SET STATUS_ID = 1
+                WHERE RADICADO = %s
+                """,
+                (radicado,),
+            )
+            conn.commit()
+            cur.close()
         win.destroy()  # Cierra la ventana después de actualizar el estado
 
     # Configurar el evento de cierre de la ventana
@@ -4570,9 +4580,9 @@ class DashboardWindow(QtWidgets.QMainWindow):
         # ——————————————————————————————
         self.lbl_saludo = QtWidgets.QLabel(f"Bienvenido, {first_name} {last_name}")
         self.lbl_saludo.setAlignment(QtCore.Qt.AlignCenter)
-        # Dejamos un color “por defecto neutral” aquí; lo ajustaremos en apply_theme
+        # Color inicial se ajustará luego en apply_theme
         self.lbl_saludo.setStyleSheet("""
-            color: #FFFFFF;              /* inicialmente blanco, asumiendo tema oscuro */
+            color: #FFFFFF;              /* placeholder, será reemplazado */
             font-size: 28px;
             font-weight: 600;
             background: transparent;
@@ -4713,27 +4723,7 @@ class DashboardWindow(QtWidgets.QMainWindow):
         """
         if hasattr(self, "cmb_role"):
             if theme == "light":
-                # En tema oscuro, background blanco y texto negro
-                self.cmb_role.setStyleSheet("""
-                    QComboBox {
-                        background-color: rgba(255, 255, 255, 150);
-                        color: #000000;
-                        border-radius: 10px;
-                        padding: 8px 16px;
-                        font-size: 14px;
-                        font-weight: bold;
-                    }
-                    QComboBox::drop-down { border: none; }
-
-                    /* Cuando se abra la lista desplegable, que el fondo también sea blanco y texto negro */
-                    QComboBox QAbstractItemView {
-                        background-color: #FFFFFF;
-                        color: #000000;
-                        selection-background-color: #E0E0E0;
-                    }
-                """)
-            else:
-                # En tema claro, background negro y texto blanco
+                # En tema claro, usaremos fondo negro semitransparente y texto blanco
                 self.cmb_role.setStyleSheet("""
                     QComboBox {
                         background-color: rgba(0, 0, 0, 150);
@@ -4745,26 +4735,46 @@ class DashboardWindow(QtWidgets.QMainWindow):
                     }
                     QComboBox::drop-down { border: none; }
 
-                    /* Cuando se abra la lista desplegable, que el fondo también sea negro y texto blanco */
+                    /* Desplegable también oscuro */
                     QComboBox QAbstractItemView {
                         background-color: #000000;
                         color: #FFFFFF;
                         selection-background-color: #303030;
                     }
                 """)
+            else:
+                # En tema oscuro, fondo blanco semitransparente y texto negro
+                self.cmb_role.setStyleSheet("""
+                    QComboBox {
+                        background-color: rgba(255, 255, 255, 150);
+                        color: #000000;
+                        border-radius: 10px;
+                        padding: 8px 16px;
+                        font-size: 14px;
+                        font-weight: bold;
+                    }
+                    QComboBox::drop-down { border: none; }
+
+                    /* Desplegable claro */
+                    QComboBox QAbstractItemView {
+                        background-color: #FFFFFF;
+                        color: #000000;
+                        selection-background-color: #E0E0E0;
+                    }
+                """)
         if hasattr(self, "lbl_saludo"):
             if theme == "light":
-                # Texto blanco sobre fondo oscuro
+                # Texto negro sobre fondo claro
                 self.lbl_saludo.setStyleSheet("""
-                    color: #FFFFFF;
+                    color: #000000;
                     font-size: 28px;
                     font-weight: 600;
                     background: transparent;
                 """)
             else:
-                # Texto negro sobre fondo claro
+                # Texto blanco sobre fondo oscuro
                 self.lbl_saludo.setStyleSheet("""
-                    color: #000000;
+                    color: #FFFFFF;
                     font-size: 28px;
                     font-weight: 600;
                     background: transparent;


### PR DESCRIPTION
## Summary
- invert combo box colors depending on theme for better readability
- declare assignment variables as nonlocal in calidad loader

## Testing
- `python -m py_compile dashboard.py`


------
https://chatgpt.com/codex/tasks/task_b_683be52b13c08331bc95c532d5079c27