### PR TITLE
Update theme text colors and safe closing

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -524,14 +524,18 @@ def iniciar_tipificacion(parent_root, conn, current_user_id):
 
     def on_close():
         # Si la ventana se cierra sin guardar, cambiamos el estado de la asignación a 1
-        cur = conn.cursor()
-        cur.execute("""
-            UPDATE ASIGNACION_TIPIFICACION 
-            SET STATUS_ID = 1 
-            WHERE RADICADO = %s
-        """, (radicado,))
-        conn.commit()
-        cur.close()
+        if radicado is not None:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                UPDATE ASIGNACION_TIPIFICACION
+                SET STATUS_ID = 1
+                WHERE RADICADO = %s
+                """,
+                (radicado,),
+            )
+            conn.commit()
+            cur.close()
         win.destroy()  # Cierra la ventana después de actualizar el estado
 
     # Configurar el evento de cierre de la ventana
@@ -1864,14 +1868,18 @@ def iniciar_calidad(parent_root, conn, current_user_id):
 
     def on_close():
         # Si la ventana se cierra sin guardar, cambiamos el estado de la asignación a 1
-        cur = conn.cursor()
-        cur.execute("""
-            UPDATE ASIGNACION_TIPIFICACION 
-            SET STATUS_ID = 1 
-            WHERE RADICADO = %s
-        """, (radicado,))
-        conn.commit()
-        cur.close()
+        if radicado is not None:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                UPDATE ASIGNACION_TIPIFICACION
+                SET STATUS_ID = 1
+                WHERE RADICADO = %s
+                """,
+                (radicado,),
+            )
+            conn.commit()
+            cur.close()
         win.destroy()  # Cierra la ventana después de actualizar el estado
 
     # Configurar el evento de cierre de la ventana
@@ -4570,9 +4578,9 @@ class DashboardWindow(QtWidgets.QMainWindow):
         # ——————————————————————————————
         self.lbl_saludo = QtWidgets.QLabel(f"Bienvenido, {first_name} {last_name}")
         self.lbl_saludo.setAlignment(QtCore.Qt.AlignCenter)
-        # Dejamos un color “por defecto neutral” aquí; lo ajustaremos en apply_theme
+        # Color inicial se ajustará luego en apply_theme
         self.lbl_saludo.setStyleSheet("""
-            color: #FFFFFF;              /* inicialmente blanco, asumiendo tema oscuro */
+            color: #FFFFFF;              /* placeholder, será reemplazado */
             font-size: 28px;
             font-weight: 600;
             background: transparent;
@@ -4719,11 +4727,14 @@ class DashboardWindow(QtWidgets.QMainWindow):
                         background-color: rgba(255, 255, 255, 150);
                         color: #000000;
                         border-radius: 10px;
-                        padding: 8px 16px;
+                        padding: 8px 28px 8px 28px; /* espacio simétrico */
                         font-size: 14px;
                         font-weight: bold;
                     }
-                    QComboBox::drop-down { border: none; }
+                    QComboBox::drop-down {
+                        border: none;
+                        width: 24px;                    /* para balancear el texto */
+                    }
 
                     /* Cuando se abra la lista desplegable, que el fondo también sea blanco y texto negro */
                     QComboBox QAbstractItemView {
@@ -4739,11 +4750,14 @@ class DashboardWindow(QtWidgets.QMainWindow):
                         background-color: rgba(0, 0, 0, 150);
                         color: #FFFFFF;
                         border-radius: 10px;
-                        padding: 8px 16px;
+                        padding: 8px 28px 8px 28px; /* espacio simétrico */
                         font-size: 14px;
                         font-weight: bold;
                     }
-                    QComboBox::drop-down { border: none; }
+                    QComboBox::drop-down {
+                        border: none;
+                        width: 24px;                    /* para balancear el texto */
+                    }
 
                     /* Cuando se abra la lista desplegable, que el fondo también sea negro y texto blanco */
                     QComboBox QAbstractItemView {
@@ -4754,17 +4768,17 @@ class DashboardWindow(QtWidgets.QMainWindow):
                 """)
         if hasattr(self, "lbl_saludo"):
             if theme == "light":
-                # Texto blanco sobre fondo oscuro
+                # Texto negro sobre fondo claro
                 self.lbl_saludo.setStyleSheet("""
-                    color: #FFFFFF;
+                    color: #000000;
                     font-size: 28px;
                     font-weight: 600;
                     background: transparent;
                 """)
             else:
-                # Texto negro sobre fondo claro
+                # Texto blanco sobre fondo oscuro
                 self.lbl_saludo.setStyleSheet("""
-                    color: #000000;
+                    color: #FFFFFF;
                     font-size: 28px;
                     font-weight: 600;
                     background: transparent;
@@ -4976,8 +4990,18 @@ class DashboardWindow(QtWidgets.QMainWindow):
             aceptado = tk.BooleanVar(master=self._tk_root, value=False)
             ctk.CTkLabel(win, text="Tipo de Paquete:", text_color=fg,
                         fg_color=bg, font=("Arial",14,"bold")).pack(pady=10)
-            ctk.CTkOptionMenu(win, values=["DIGITACION","CALIDAD"], variable=tipo_var,
-                            fg_color=bg).pack(pady=5)
+            opt_bg = "#000000" if theme == "light" else "#FFFFFF"
+            opt_fg = "#FFFFFF" if theme == "light" else "#000000"
+            ctk.CTkOptionMenu(
+                win,
+                values=["DIGITACION","CALIDAD"],
+                variable=tipo_var,
+                fg_color=opt_bg,
+                text_color=opt_fg,
+                button_color=opt_bg,
+                button_hover_color=opt_bg,
+                font=("Arial",14,"bold")
+            ).pack(pady=5)
             def ok():
                 aceptado.set(True)
                 win.destroy()


### PR DESCRIPTION
## Summary
- adjust welcome label text color based on theme
- handle theme comment for label color
- ensure status resets on window close when radicado is known
- center text inside role combobox and style package type selector

## Testing
- `python -m py_compile dashboard.py`


------
https://chatgpt.com/codex/tasks/task_b_683be52b13c08331bc95c532d5079c27