### PR TITLE
Fix service field disappearance

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -961,13 +961,39 @@ def iniciar_tipificacion(parent_root, conn, current_user_id):
     
     dynamic_row = fixed_row + 1  # agrega estas variables ANTES de la función
     dynamic_col = 0
-    
+
+    def reflow_service_blocks():
+        """Recoloca todos los bloques de servicio en orden."""
+        nonlocal dynamic_row, dynamic_col
+        row = fixed_row + 1
+        col = 0
+        for frames in service_frames:
+            for frm in frames:
+                frm.grid_configure(row=row, column=col)
+                col += 1
+                if col == 3:
+                    col = 0
+                    row += 1
+            if col != 0:
+                row += 1
+                col = 0
+        dynamic_row = row
+        dynamic_col = col
+
     def add_service_block():
         nonlocal dynamic_row, dynamic_col
         dv = {}
         current_frames = []
         
         skip_obs = len(detail_vars) >= 1
+
+        # Start a new row if the last block did not end at column 0.
+        # This prevents overlaps when the number of fields isn't a
+        # multiple of three.
+        if dynamic_col != 0:
+            dynamic_row += 1
+            dynamic_col = 0
+
 
         for campo, icon_url in DETAIL_ICONS.items():
             if campo not in campos_paquete:
@@ -1030,7 +1056,7 @@ def iniciar_tipificacion(parent_root, conn, current_user_id):
                     return P == "" or P.isalnum()
                 vcmd_cs = (win.register(only_alphanum), '%P')
 
-                def to_upper_and_filter(*args):
+                def to_upper_and_filter(*args, var=var):
                     txt = var.get()
                     filtered = ''.join(ch for ch in txt if ch.isalnum()).upper()
                     if txt != filtered:
@@ -1132,6 +1158,8 @@ def iniciar_tipificacion(parent_root, conn, current_user_id):
         if len(service_frames) > 1:
             btn_del.configure(state='normal')
 
+        reflow_service_blocks()
+
 
     if any(c in campos_paquete for c in DETAIL_ICONS):
         add_service_block()
@@ -1161,6 +1189,8 @@ def iniciar_tipificacion(parent_root, conn, current_user_id):
             # Si ya no hay más servicios adicionales, desactivar botón
             if len(service_frames) <= 1:
                 btn_del.configure(state='disabled')
+
+            reflow_service_blocks()
 
     # -----------------------------
     # Validar y guardar en BD
@@ -2450,6 +2480,24 @@ def iniciar_calidad(parent_root, conn, current_user_id):
     
     dynamic_row = fixed_row + 1  # agrega estas variables ANTES de la función
     dynamic_col = 0
+    def reflow_service_blocks():
+        """Recoloca todos los bloques de servicio en orden."""
+        nonlocal dynamic_row, dynamic_col
+        row = fixed_row + 1
+        col = 0
+        for frames in service_frames:
+            for frm in frames:
+                frm.grid_configure(row=row, column=col)
+                col += 1
+                if col == 3:
+                    col = 0
+                    row += 1
+            if col != 0:
+                row += 1
+                col = 0
+        dynamic_row = row
+        dynamic_col = col
+
     
     def add_service_block():
         nonlocal dynamic_row, dynamic_col
@@ -2457,6 +2505,10 @@ def iniciar_calidad(parent_root, conn, current_user_id):
         current_frames = []
         
         skip_obs = len(detail_vars) >= 1
+        # Start a new row if the last block did not end at column 0
+        if dynamic_col != 0:
+            dynamic_row += 1
+            dynamic_col = 0
 
         for campo, icon_url in DETAIL_ICONS.items():
             if campo not in campos_paquete:
@@ -2511,7 +2563,7 @@ def iniciar_calidad(parent_root, conn, current_user_id):
                     return P == "" or P.isalnum()
                 vcmd_cs = (win.register(only_alphanum), '%P')
 
-                def to_upper_and_filter(*args):
+                def to_upper_and_filter(*args, var=var):
                     txt = var.get()
                     filtered = ''.join(ch for ch in txt if ch.isalnum()).upper()
                     if txt != filtered:
@@ -2613,6 +2665,7 @@ def iniciar_calidad(parent_root, conn, current_user_id):
         if len(service_frames) > 1:
             btn_del.configure(state='normal')
 
+        reflow_service_blocks()
 
     if any(c in campos_paquete for c in DETAIL_ICONS):
         add_service_block()
@@ -2642,6 +2695,8 @@ def iniciar_calidad(parent_root, conn, current_user_id):
 
             if len(service_frames) <= 1:
                 btn_del.configure(state='disabled')
+
+            reflow_service_blocks()
 
     # -----------------------------
     # Validar y guardar en BD


### PR DESCRIPTION
## Summary
- add `reflow_service_blocks` helper to reposition service widgets
- ensure `to_upper_and_filter` keeps correct variable reference
- invoke `reflow_service_blocks` after adding or removing a service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6840522edcac8331a8a91d4ff8f05227