### PR TITLE
Refine progress queries

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3192,9 +3192,9 @@ def ver_progreso(root, conn):
             "SELECT UPPER(s.NAME) AS ESTADO, COUNT(*) AS CNT "
             "FROM ASIGNACION_TIPIFICACION a "
             "JOIN STATUS s ON a.STATUS_ID = s.ID "
-            "JOIN TIPIFICACION t ON t.ASIGNACION_ID = a.RADICADO "
-            "JOIN USERS u ON t.USER_ID = u.ID "
-            f"WHERE {where} GROUP BY s.NAME ORDER BY s.NAME"
+            "LEFT JOIN TIPIFICACION t ON t.ASIGNACION_ID = a.RADICADO "
+            "LEFT JOIN USERS u ON a.USER_ASIGNED = u.ID "
+            f"WHERE {where} AND s.ID <= 4 GROUP BY s.NAME ORDER BY s.NAME"
         )
         cur.execute(sql1, params)
         rows1 = cur.fetchall()
@@ -3211,9 +3211,9 @@ def ver_progreso(root, conn):
             "SELECT COUNT(*) "
             "FROM ASIGNACION_TIPIFICACION a "
             "LEFT JOIN TIPIFICACION t ON t.ASIGNACION_ID = a.RADICADO "
-            "LEFT JOIN USERS u        ON t.USER_ID        = u.ID "
+            "LEFT JOIN USERS u        ON a.USER_ASIGNED   = u.ID "
             "LEFT JOIN STATUS s       ON a.STATUS_ID      = s.ID "
-            f"WHERE {where} AND a.STATUS_ID <> 1"
+            f"WHERE {where} AND a.STATUS_ID <> 1 AND s.ID <= 4"
         )
         cur2.execute(sql_tot_asig, params)
         total_asignados = cur2.fetchone()[0] or 0
@@ -3224,9 +3224,9 @@ def ver_progreso(root, conn):
             "SELECT COUNT(*) "
             "FROM ASIGNACION_TIPIFICACION a "
             "LEFT JOIN TIPIFICACION t ON t.ASIGNACION_ID = a.RADICADO "
-            "LEFT JOIN USERS u        ON t.USER_ID        = u.ID "
+            "LEFT JOIN USERS u        ON a.USER_ASIGNED   = u.ID "
             "LEFT JOIN STATUS s       ON a.STATUS_ID      = s.ID "
-            f"WHERE {where}"
+            f"WHERE {where} AND s.ID <= 4"
         )
         cur3.execute(sql_tot_all, params)
         total_global = cur3.fetchone()[0] or 0
@@ -3256,7 +3256,7 @@ def ver_progreso(root, conn):
                 JOIN TIPIFICACION t ON t.ASIGNACION_ID = a.RADICADO
                 JOIN USERS u ON t.USER_ID = u.ID
                 JOIN STATUS s ON a.STATUS_ID = s.ID
-                WHERE {where}
+                WHERE {where} AND s.ID <= 4
                     -- excluir los que son exactamente medianoche
                     AND t.fecha_creacion <> CAST(t.fecha_creacion AS date)
             ) sub
@@ -3287,10 +3287,10 @@ def ver_progreso(root, conn):
             "       SUM(CASE WHEN a.STATUS_ID=3 THEN 1 ELSE 0 END) AS PROCESADOS, "
             "       SUM(CASE WHEN a.STATUS_ID=4 THEN 1 ELSE 0 END) AS CON_OBS "
             "FROM ASIGNACION_TIPIFICACION a "
-            "JOIN TIPIFICACION t ON t.ASIGNACION_ID = a.RADICADO "
-            "JOIN USERS u ON t.USER_ID = u.ID "
+            "LEFT JOIN TIPIFICACION t ON t.ASIGNACION_ID = a.RADICADO "
+            "JOIN USERS u ON u.ID = CASE WHEN a.STATUS_ID=2 THEN a.USER_ASIGNED ELSE t.USER_ID END "
             "JOIN STATUS s ON a.STATUS_ID = s.ID "
-            f"WHERE {where} GROUP BY u.ID, u.FIRST_NAME, u.LAST_NAME ORDER BY USUARIO"
+            f"WHERE {where} AND s.ID <= 4 GROUP BY u.ID, u.FIRST_NAME, u.LAST_NAME ORDER BY USUARIO"
         )
         cur3.execute(sql2, params)
         rows2 = cur3.fetchall()
@@ -3315,7 +3315,7 @@ def ver_progreso(root, conn):
                JOIN TIPIFICACION t ON t.ASIGNACION_ID = a.RADICADO
                JOIN USERS u       ON t.USER_ID        = u.ID
                JOIN STATUS s      ON a.STATUS_ID      = s.ID
-               WHERE {where}
+               WHERE {where} AND s.ID <= 4
                  -- excluir los que son exactamente medianoche
                  AND t.fecha_creacion <> CAST(t.fecha_creacion AS date)
            ) sub2
@@ -3659,7 +3659,6 @@ def ver_progreso(root, conn):
     fecha_desde.delete(0, 'end')
     # Actualiza solo cuando el usuario selecciona una fecha o termina de editar
     fecha_desde.bind("<<DateEntrySelected>>", lambda e: actualizar_tabs())
-    fecha_desde.bind("<FocusOut>", lambda e: actualizar_tabs())
 
     ctk.CTkLabel(sidebar, text="Hasta:").grid(row=3, column=0, sticky="w")
     fecha_hasta = DateEntry(sidebar, width=12, locale='es_CO',
@@ -3669,7 +3668,6 @@ def ver_progreso(root, conn):
     fecha_hasta.delete(0, 'end')
     # Igual que para la fecha inicial, actualiza al finalizar la selección
     fecha_hasta.bind("<<DateEntrySelected>>", lambda e: actualizar_tabs())
-    fecha_hasta.bind("<FocusOut>", lambda e: actualizar_tabs())
 
     ctk.CTkButton(sidebar, text="Limpiar fechas", command=limpiar_fechas, width=100).grid(row=4, column=0, columnspan=2, pady=(10,0))
     ctk.CTkButton(sidebar, text="Exportar", command=exportar, width=100).grid(row=5, column=0, columnspan=2, pady=(10,0))
@@ -3759,7 +3757,7 @@ def actualizar_tabs(win, conn, num_paquete,where, params):
         SELECT UPPER(s.NAME) AS ESTADO, COUNT(*) AS CNT
           FROM ASIGNACION_TIPIFICACION at
           JOIN STATUS s ON at.STATUS_ID = s.ID
-         WHERE at.NUM_PAQUETE = %s
+         WHERE at.NUM_PAQUETE = %s AND s.ID <= 4
          GROUP BY s.NAME
          ORDER BY s.NAME
     """, (num_paquete,))
@@ -3802,11 +3800,10 @@ def actualizar_tabs(win, conn, num_paquete,where, params):
                SUM(CASE WHEN at.STATUS_ID=2 THEN 1 ELSE 0 END) AS PENDIENTES,
                SUM(CASE WHEN at.STATUS_ID=3 THEN 1 ELSE 0 END) AS PROCESADOS,
                SUM(CASE WHEN at.STATUS_ID=4 THEN 1 ELSE 0 END) AS CON_OBS
-          FROM TIPIFICACION t
-          JOIN USERS u     ON t.USER_ID = u.ID
-          JOIN ASIGNACION_TIPIFICACION at
-            ON at.RADICADO = t.ASIGNACION_ID
-         WHERE at.NUM_PAQUETE = %s
+          FROM ASIGNACION_TIPIFICACION at
+          LEFT JOIN TIPIFICACION t ON t.ASIGNACION_ID = at.RADICADO
+          JOIN USERS u     ON u.ID = CASE WHEN at.STATUS_ID=2 THEN at.USER_ASIGNED ELSE t.USER_ID END
+         WHERE at.NUM_PAQUETE = %s AND at.STATUS_ID <= 4
          GROUP BY u.ID, u.FIRST_NAME, u.LAST_NAME
          ORDER BY USUARIO
     """, (num_paquete,))


### PR DESCRIPTION
## Summary
- filter out statuses with ID greater than 4 when viewing progress
- count pending items using `USER_ASIGNED` but use `TIPIFICACION.USER_ID` for other states

## Testing
- `python -m py_compile dashboard.py login_app.py db_connection.py version.py`


------
https://chatgpt.com/codex/tasks/task_b_68499d4098248331bc562dbd6542223c