### PR TITLE
Fix user counts for pending assignments

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3281,16 +3281,21 @@ def ver_progreso(root, conn):
         # 1) Conteos por usuario
         cur3 = conn.cursor()
         sql2 = (
-            "SELECT u.ID, "
-            "       u.FIRST_NAME + ' ' + u.LAST_NAME AS USUARIO, "
-            "       SUM(CASE WHEN a.STATUS_ID=2 THEN 1 ELSE 0 END) AS PENDIENTES, "
-            "       SUM(CASE WHEN a.STATUS_ID=3 THEN 1 ELSE 0 END) AS PROCESADOS, "
-            "       SUM(CASE WHEN a.STATUS_ID=4 THEN 1 ELSE 0 END) AS CON_OBS "
+            "SELECT "
+            "  COALESCE(u_t.ID, u_a.ID) AS ID, "
+            "  COALESCE(u_t.FIRST_NAME + ' ' + u_t.LAST_NAME, "
+            "           u_a.FIRST_NAME + ' ' + u_a.LAST_NAME, 'SIN USUARIO') AS USUARIO, "
+            "  SUM(CASE WHEN a.STATUS_ID=2 THEN 1 ELSE 0 END) AS PENDIENTES, "
+            "  SUM(CASE WHEN a.STATUS_ID=3 THEN 1 ELSE 0 END) AS PROCESADOS, "
+            "  SUM(CASE WHEN a.STATUS_ID=4 THEN 1 ELSE 0 END) AS CON_OBS "
             "FROM ASIGNACION_TIPIFICACION a "
             "LEFT JOIN TIPIFICACION t ON t.ASIGNACION_ID = a.RADICADO "
-            "JOIN USERS u ON u.ID = CASE WHEN a.STATUS_ID=2 THEN a.USER_ASIGNED ELSE t.USER_ID END "
+            "LEFT JOIN USERS u_a ON a.USER_ASIGNED = u_a.ID "
+            "LEFT JOIN USERS u_t ON t.USER_ID = u_t.ID "
             "JOIN STATUS s ON a.STATUS_ID = s.ID "
-            f"WHERE {where} AND s.ID <= 4 GROUP BY u.ID, u.FIRST_NAME, u.LAST_NAME ORDER BY USUARIO"
+            f"WHERE {where} AND s.ID <= 4 "
+            "GROUP BY COALESCE(u_t.ID, u_a.ID), u_t.FIRST_NAME, u_t.LAST_NAME, u_a.FIRST_NAME, u_a.LAST_NAME "
+            "ORDER BY USUARIO"
         )
         cur3.execute(sql2, params)
         rows2 = cur3.fetchall()
@@ -3795,16 +3800,20 @@ def actualizar_tabs(win, conn, num_paquete,where, params):
 
     cur = conn.cursor()
     cur.execute("""
-        SELECT u.ID,
-               u.FIRST_NAME + ' ' + u.LAST_NAME AS USUARIO,
+        SELECT COALESCE(u_t.ID, u_a.ID) AS ID,
+               COALESCE(u_t.FIRST_NAME + ' ' + u_t.LAST_NAME,
+                        u_a.FIRST_NAME + ' ' + u_a.LAST_NAME,
+                        'SIN USUARIO') AS USUARIO,
                SUM(CASE WHEN at.STATUS_ID=2 THEN 1 ELSE 0 END) AS PENDIENTES,
                SUM(CASE WHEN at.STATUS_ID=3 THEN 1 ELSE 0 END) AS PROCESADOS,
                SUM(CASE WHEN at.STATUS_ID=4 THEN 1 ELSE 0 END) AS CON_OBS
           FROM ASIGNACION_TIPIFICACION at
           LEFT JOIN TIPIFICACION t ON t.ASIGNACION_ID = at.RADICADO
-          JOIN USERS u     ON u.ID = CASE WHEN at.STATUS_ID=2 THEN at.USER_ASIGNED ELSE t.USER_ID END
+          LEFT JOIN USERS u_a ON at.USER_ASIGNED = u_a.ID
+          LEFT JOIN USERS u_t ON t.USER_ID = u_t.ID
          WHERE at.NUM_PAQUETE = %s AND at.STATUS_ID <= 4
-         GROUP BY u.ID, u.FIRST_NAME, u.LAST_NAME
+         GROUP BY COALESCE(u_t.ID, u_a.ID), u_t.FIRST_NAME, u_t.LAST_NAME,
+                  u_a.FIRST_NAME, u_a.LAST_NAME
          ORDER BY USUARIO
     """, (num_paquete,))
     usuarios = cur.fetchall(); cur.close()


### PR DESCRIPTION
## Summary
- ensure pending assignments show assigned user's info when listing progress by user

## Testing
- `python -m py_compile dashboard.py login_app.py db_connection.py version.py`


------
https://chatgpt.com/codex/tasks/task_b_6849a240025c83319e54703871c6eb4b