### PR TITLE
Fix pendiente user listing

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3292,9 +3292,12 @@ def ver_progreso(root, conn):
             "LEFT JOIN TIPIFICACION t ON t.ASIGNACION_ID = a.RADICADO "
             "LEFT JOIN USERS u_a ON a.USER_ASIGNED = u_a.ID "
             "LEFT JOIN USERS u_t ON t.USER_ID = u_t.ID "
+            "LEFT JOIN USERS u   ON COALESCE(t.USER_ID, a.USER_ASIGNED) = u.ID "
             "JOIN STATUS s ON a.STATUS_ID = s.ID "
             f"WHERE {where} AND s.ID <= 4 "
-            "GROUP BY COALESCE(u_t.ID, u_a.ID), u_t.FIRST_NAME, u_t.LAST_NAME, u_a.FIRST_NAME, u_a.LAST_NAME "
+            "GROUP BY COALESCE(u_t.ID, u_a.ID), "
+            "         COALESCE(u_t.FIRST_NAME + ' ' + u_t.LAST_NAME, "
+            "                  u_a.FIRST_NAME + ' ' + u_a.LAST_NAME) "
             "ORDER BY USUARIO"
         )
         cur3.execute(sql2, params)
@@ -3800,20 +3803,24 @@ def actualizar_tabs(win, conn, num_paquete,where, params):
 
     cur = conn.cursor()
     cur.execute("""
-        SELECT COALESCE(u_t.ID, u_a.ID) AS ID,
-               COALESCE(u_t.FIRST_NAME + ' ' + u_t.LAST_NAME,
-                        u_a.FIRST_NAME + ' ' + u_a.LAST_NAME,
-                        'SIN USUARIO') AS USUARIO,
-               SUM(CASE WHEN at.STATUS_ID=2 THEN 1 ELSE 0 END) AS PENDIENTES,
-               SUM(CASE WHEN at.STATUS_ID=3 THEN 1 ELSE 0 END) AS PROCESADOS,
-               SUM(CASE WHEN at.STATUS_ID=4 THEN 1 ELSE 0 END) AS CON_OBS
-          FROM ASIGNACION_TIPIFICACION at
-          LEFT JOIN TIPIFICACION t ON t.ASIGNACION_ID = at.RADICADO
-          JOIN USERS u ON u.ID = CASE WHEN at.STATUS_ID=2 THEN at.USER_ASIGNED ELSE t.USER_ID END
-         WHERE at.NUM_PAQUETE = %s AND at.STATUS_ID <= 4
-         GROUP BY COALESCE(u_t.ID, u_a.ID), u_t.FIRST_NAME, u_t.LAST_NAME,
-                  u_a.FIRST_NAME, u_a.LAST_NAME
-         ORDER BY USUARIO
+        SELECT
+            COALESCE(u_t.ID, u_a.ID) AS ID,
+            COALESCE(u_t.FIRST_NAME + ' ' + u_t.LAST_NAME,
+                     u_a.FIRST_NAME + ' ' + u_a.LAST_NAME,
+                     'SIN USUARIO') AS USUARIO,
+            SUM(CASE WHEN at.STATUS_ID=2 THEN 1 ELSE 0 END) AS PENDIENTES,
+            SUM(CASE WHEN at.STATUS_ID=3 THEN 1 ELSE 0 END) AS PROCESADOS,
+            SUM(CASE WHEN at.STATUS_ID=4 THEN 1 ELSE 0 END) AS CON_OBS
+        FROM ASIGNACION_TIPIFICACION at
+        LEFT JOIN TIPIFICACION t ON t.ASIGNACION_ID = at.RADICADO
+        LEFT JOIN USERS u_a ON at.USER_ASIGNED = u_a.ID
+        LEFT JOIN USERS u_t ON t.USER_ID = u_t.ID
+        LEFT JOIN USERS u   ON COALESCE(t.USER_ID, at.USER_ASIGNED) = u.ID
+        WHERE at.NUM_PAQUETE = %s AND at.STATUS_ID <= 4
+        GROUP BY COALESCE(u_t.ID, u_a.ID),
+                 COALESCE(u_t.FIRST_NAME + ' ' + u_t.LAST_NAME,
+                          u_a.FIRST_NAME + ' ' + u_a.LAST_NAME)
+        ORDER BY USUARIO
     """, (num_paquete,))
     usuarios = cur.fetchall(); cur.close()
 


### PR DESCRIPTION
## Summary
- allow progress view to show pending assignments by user
- unify queries that aggregate per user

## Testing
- `python -m py_compile dashboard.py`

------
https://chatgpt.com/codex/tasks/task_b_6849a977d8108331b06f2094edaa894c