### PR TITLE
Fix dashboard panel sizing

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -5259,7 +5259,10 @@ class DashboardWindow(QtWidgets.QMainWindow):
             
         # Configuración de la ventana
         self.setWindowTitle("Dashboard · Capturador De Datos")
-        self.resize(900, 900)
+        screen = QtWidgets.QApplication.primaryScreen().availableGeometry()
+        win_w = int(max(720, min(1600, screen.width() * 0.9)))
+        win_h = int(max(540, min(1200, screen.height() * 0.9)))
+        self.resize(win_w, win_h)
         self.center_on_screen()
             
         pix = QtGui.QPixmap(bg_path).scaled(
@@ -5325,6 +5328,7 @@ class DashboardWindow(QtWidgets.QMainWindow):
         v_layout.addStretch()
         v_layout.addWidget(self.panel, alignment=QtCore.Qt.AlignCenter)
         v_layout.addStretch()
+        self._update_panel_size()
 
         # ——————————————————————————————
         # 3) Encabezado con saludo
@@ -5620,7 +5624,16 @@ class DashboardWindow(QtWidgets.QMainWindow):
     def _on_resize(self, event):
         """Reposiciona el botón de tema al cambiar tamaño."""
         self.theme_btn.move(self.width() - 60, self.height() - 60)
+        if hasattr(self, "panel"):
+            self._update_panel_size()
         return super().resizeEvent(event)
+
+    def _update_panel_size(self):
+        """Ajusta el tamaño del panel según el de la ventana."""
+        win_w, win_h = self.width(), self.height()
+        panel_w = int(max(600, min(win_w * 0.7, 1000)))
+        panel_h = int(max(400, min(win_h * 0.8, 800)))
+        self.panel.setFixedSize(panel_w, panel_h)
 
     def center_on_screen(self):
         """Centra la ventana en la pantalla."""

--- a/login_app.py
+++ b/login_app.py
@@ -206,12 +206,19 @@ class LoginWindow(QtWidgets.QWidget):
 
         # y fija el icono del botón
         self.setWindowTitle("Login - Capturador De Datos")
-        self.resize(700, 800)
+        screen = QtWidgets.QApplication.primaryScreen().availableGeometry()
+        win_w = int(max(480, min(1200, screen.width() * 0.6)))
+        win_h = int(max(500, min(1000, screen.height() * 0.85)))
+        self.resize(win_w, win_h)
         self.center_on_screen()
         self.setWindowFlag(QtCore.Qt.WindowMaximizeButtonHint, False)
-        self.setFixedSize(self.width(), self.height())
-        
-        self.panel_rect = QtCore.QRect(160, 150, 400, 500)
+        self.setFixedSize(win_w, win_h)
+
+        panel_w = int(win_w * 0.57)
+        panel_h = int(win_h * 0.62)
+        x = (win_w - panel_w) // 2
+        y = (win_h - panel_h) // 2
+        self.panel_rect = QtCore.QRect(x, y, panel_w, panel_h)
 
         # Cargamos la imagen de fondo completa
         bg_path = os.path.join(os.path.dirname(__file__), "Fondo.png")
@@ -607,15 +614,17 @@ class RecuperarContrasenaWindow(QtWidgets.QWidget):
 
         # — Configuración básica de la ventana —
         self.setWindowTitle("Recuperar Contraseña")
-        self.resize(500, 400)
+        screen = QtWidgets.QApplication.primaryScreen().availableGeometry()
+        win_w = int(max(420, min(800, screen.width() * 0.5)))
+        win_h = int(max(320, min(700, screen.height() * 0.6)))
+        self.resize(win_w, win_h)
         self.setWindowFlag(QtCore.Qt.WindowMaximizeButtonHint, False)
-        self.setFixedSize(self.width(), self.height())
+        self.setFixedSize(win_w, win_h)
 
-        # — Panel centrado de 400×(altura−60) —
-        panel_width  = 400
-        panel_height = self.height() - 160
-        x = (self.width() - panel_width) // 2
-        y = (self.height() - panel_height) // 2
+        panel_width  = int(win_w * 0.8)
+        panel_height = int(win_h * 0.6)
+        x = (win_w - panel_width) // 2
+        y = (win_h - panel_height) // 2
         self.panel_rect = QtCore.QRect(x, y, panel_width, panel_height)
         
         # — Fondos escalados con suavizado —
@@ -780,9 +789,12 @@ class RecuperarContrasenaWindow(QtWidgets.QWidget):
         win = QtWidgets.QWidget()
         win.login_window = self.login_window
         win.setWindowTitle("Verificar Código")
-        win.resize(500, 400)
+        screen = QtWidgets.QApplication.primaryScreen().availableGeometry()
+        win_w = int(max(420, min(800, screen.width() * 0.5)))
+        win_h = int(max(320, min(700, screen.height() * 0.6)))
+        win.resize(win_w, win_h)
         win.setWindowFlag(QtCore.Qt.WindowMaximizeButtonHint, False)
-        win.setFixedSize(win.width(), win.height())
+        win.setFixedSize(win_w, win_h)
 
         # — Cargamos y escalamos ambos fondos —
         bg_dark  = QtGui.QPixmap(resource_path("FondoLoginDark.png")).scaled(
@@ -801,7 +813,14 @@ class RecuperarContrasenaWindow(QtWidgets.QWidget):
         win.bg_label.setGeometry(win.rect())
 
         # Definimos geometría del panel
-        panel_rect = QtCore.QRect(50, 30, 400, win.height() - 60)
+        panel_w = int(win_w * 0.8)
+        panel_h = int(win_h * 0.6)
+        panel_rect = QtCore.QRect(
+            (win_w - panel_w) // 2,
+            (win_h - panel_h) // 2,
+            panel_w,
+            panel_h,
+        )
 
         # — Blur detrás del panel —
         blurred_bg = QtWidgets.QLabel(win)
@@ -897,9 +916,12 @@ class RecuperarContrasenaWindow(QtWidgets.QWidget):
         win = QtWidgets.QWidget()
         win.login_window = self.login_window
         win.setWindowTitle("Cambiar Contraseña")
-        win.resize(400, 300)
+        screen = QtWidgets.QApplication.primaryScreen().availableGeometry()
+        win_w = int(max(380, min(700, screen.width() * 0.4)))
+        win_h = int(max(280, min(600, screen.height() * 0.5)))
+        win.resize(win_w, win_h)
         win.setWindowFlag(QtCore.Qt.WindowMaximizeButtonHint, False)
-        win.setFixedSize(win.width(), win.height())
+        win.setFixedSize(win_w, win_h)
 
         # — Fondos según tema —
         bg_dark  = QtGui.QPixmap(resource_path("FondoLoginDark.png")).scaled(
@@ -913,7 +935,14 @@ class RecuperarContrasenaWindow(QtWidgets.QWidget):
         win.bg_label.setGeometry(win.rect())
 
         # Panel
-        panel_rect = QtCore.QRect(50, 30, 300, 240)
+        panel_w = int(win_w * 0.75)
+        panel_h = int(win_h * 0.8)
+        panel_rect = QtCore.QRect(
+            (win_w - panel_w) // 2,
+            (win_h - panel_h) // 2,
+            panel_w,
+            panel_h,
+        )
         blurred_bg = QtWidgets.QLabel(win)
         base_pix = bg_dark if self.login_window.is_dark else bg_light
         crop = base_pix.copy(panel_rect)


### PR DESCRIPTION
## Summary
- keep dashboard panel within screen bounds when resizing

## Testing
- `python -m py_compile login_app.py dashboard.py db_connection.py version.py`


------
https://chatgpt.com/codex/tasks/task_b_685eb66da3f88331b3597cdaf0ff831c