### PR TITLE
Improve startup performance with lazy imports

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -33,6 +33,8 @@ import customtkinter as ctk  # sólo esto para CustomTkinter
 from PIL import Image
 import pandas as pd
 import requests
+
+session = requests.Session()
 import math
 from tkcalendar import DateEntry
 from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, PageBreak, Paragraph
@@ -69,7 +71,7 @@ def load_icon_from_url(url, size):
     if key in ICON_CACHE:
         return ICON_CACHE[key]
     try:
-        resp = requests.get(url, timeout=10)
+        resp = session.get(url, timeout=10)
         resp.raise_for_status()
         png_bytes = cairosvg.svg2png(bytestring=resp.content,
                                      output_width=size[0],


### PR DESCRIPTION
## Summary
- use a single `requests.Session` for network operations
- remove unused imports
- lazy-load the dashboard window and SQL connection
- use the session when checking for updates and downloading icons

## Testing
- `python -m py_compile login_app.py`
- `python -m py_compile dashboard.py`


------
https://chatgpt.com/codex/tasks/task_b_68668732de788331825c0d31d99f6b0c