### PR TITLE
Allow exporting unprocessed radicados

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3612,7 +3612,7 @@ def ver_progreso(root, conn, current_user_id, role_id):
         sql_export = (
             "SELECT " + ", ".join(select_cols) + " "
             "FROM ASIGNACION_TIPIFICACION a "
-            "JOIN TIPIFICACION t               ON t.ASIGNACION_ID          = a.RADICADO "
+            "LEFT JOIN TIPIFICACION t          ON t.ASIGNACION_ID          = a.RADICADO "
             "LEFT JOIN TIPO_DOC td             ON t.TIPO_DOC_ID            = td.ID "
             "LEFT JOIN USERS u                 ON t.USER_ID                = u.ID "
             "LEFT JOIN TIPIFICACION_DETALLES d ON d.TIPIFICACION_ID        = t.ID "


### PR DESCRIPTION
## Summary
- include unprocessed records in the `ver_progreso` export by left joining `TIPIFICACION`

## Testing
- `python -m py_compile dashboard.py db_connection.py login_app.py version.py`

------
https://chatgpt.com/codex/tasks/task_b_688a2dbdb62c83318544af202053f1f4