### PR TITLE
Cuenta copago en exportación y permite login con Enter

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3681,7 +3681,7 @@ def ver_progreso(root, conn, current_user_id, role_id):
                     count += 1
 
             if "CUOTA_MODERADORA_O_COPAGO" in group.columns and group["CUOTA_MODERADORA_O_COPAGO"].apply(
-                lambda v: pd.notna(v) and str(v).strip() not in ("", "0")
+                lambda v: pd.notna(v) and str(v).strip() != ""
             ).any():
                 count += 1
 

--- a/login_app.py
+++ b/login_app.py
@@ -305,6 +305,9 @@ class LoginWindow(QtWidgets.QWidget):
 
         vbox.addLayout(hpwd)
 
+        # Permitir iniciar sesión con Enter
+        self.edit_doc.returnPressed.connect(self.on_login)
+        self.edit_pwd.returnPressed.connect(self.on_login)
 
         # Botón Iniciar sesión
         btn = QtWidgets.QPushButton("Iniciar sesión", self.panel)
@@ -319,6 +322,8 @@ class LoginWindow(QtWidgets.QWidget):
                 background-color: #339CFF;
             }
         """)
+        btn.setDefault(True)
+        btn.setAutoDefault(True)
         btn.clicked.connect(self.on_login)
         vbox.addWidget(btn, alignment=QtCore.Qt.AlignCenter)
 


### PR DESCRIPTION
## Summary
- Count "cuota moderadora/copago" even when it is 0 in export field tally
- Allow logging in by pressing Enter on the document or password fields

## Testing
- `python -m py_compile dashboard.py login_app.py`


------
https://chatgpt.com/codex/tasks/task_b_6899fa50cce08331a821eddad4aeceec